### PR TITLE
Prevent busy wait and handle password errors in daemon loop

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -44,6 +44,10 @@ var daemonCmd = &cobra.Command{
 				}
 
 				secretPassword, err := secrets.GetSecret(cfg.Username, consts.LabelPassword)
+				if err != nil {
+					fmt.Println("Ошибка получения пароля из keyring:", err)
+					return
+				}
 
 				vpnCfg := models.ConfigVPN{
 					Host:     cfg.VPNHost,
@@ -59,9 +63,9 @@ var daemonCmd = &cobra.Command{
 			} else {
 				logs.Logger.Println("[✓] VPN уже подключён.")
 			}
-		}
 
-		time.Sleep(30 * time.Second)
+			time.Sleep(30 * time.Second)
+		}
 
 	},
 }


### PR DESCRIPTION
## Summary
- add missing error check when fetching VPN password from keyring
- sleep between reconnect attempts to avoid busy loop

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ad8cd1eb20832d89cfdec9c08f7395